### PR TITLE
Update blink.lua match highlighting

### DIFF
--- a/lua/nightfox/group/modules/blink.lua
+++ b/lua/nightfox/group/modules/blink.lua
@@ -14,7 +14,7 @@ function M.get(spec, config, opts)
 
     BlinkCmpLabel              = { fg = spec.fg1, },
     BlinkCmpLabelDeprecated    = { fg = syn.dep, style = "strikethrough" },
-    BlinkCmpLabelMatch         = { fg = syn.func, },
+    BlinkCmpLabelMatch         = { fg = syn.regex, },
 
     BlinkCmpKindDefault       = { fg = spec.fg2, },
     BlinkCmpLabelDetail       = { link = "Comment" },


### PR DESCRIPTION
When using `blink.cmp` the matching completion string appears the same as the underlying text (both function highlighting) so it's not possible to see the matching text that was typed.

Before:
<img width="614" alt="Screenshot 2025-03-26 at 10 09 08" src="https://github.com/user-attachments/assets/fe132998-6214-4997-a0a4-7fc954637a51" />

After:
<img width="479" alt="Screenshot 2025-03-26 at 15 27 48" src="https://github.com/user-attachments/assets/10362988-1921-4445-ba83-4291f7fb6be8" />
